### PR TITLE
Be clear more clear about results of enablePersistence()

### DIFF
--- a/firestore/test.firestore.js
+++ b/firestore/test.firestore.js
@@ -24,10 +24,6 @@ describe("firestore", () => {
       );
 
       firebase.firestore().enablePersistence()
-        .then(function() {
-            // Initialize Cloud Firestore through firebase
-            var db = firebase.firestore();
-        })
         .catch(function(err) {
             if (err.code == 'failed-precondition') {
                 // Multiple tabs open, persistence can only be enabled
@@ -39,6 +35,7 @@ describe("firestore", () => {
                 // ...
             }
         });
+      // Subsequent queries will use persistence, if it was enabled successfully
       // [END initialize_persistence]
     });
 


### PR DESCRIPTION
The code sample here suggests that the developer should use the promise returned from enablePersistence() to get a hold of a new Firestore instance when the promise resolves successfully.  This isn't a requirement, as subsequent queries are supposed to be enqueued to execute after enablePersistence is complete, in either success or failure cases.