### PR TITLE
Bump sdk version. Run cache size test earlier.

### DIFF
--- a/firestore/index.html
+++ b/firestore/index.html
@@ -12,8 +12,8 @@
 
   <script>mocha.setup('bdd')</script>
 
-  <script src="https://www.gstatic.com/firebasejs/5.9.0/firebase.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/5.9.0/firebase-firestore.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/7.7.0/firebase.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/7.7.0/firebase-firestore.js"></script>
   <script src="test.firestore.js"></script>
   <script src="test.solution-arrays.js"></script>
   <script src="test.solution-counters.js"></script>

--- a/firestore/test.firestore.js
+++ b/firestore/test.firestore.js
@@ -11,6 +11,14 @@ describe("firestore", () => {
         //firebase.firestore.setLogLevel("debug");
     });
 
+    it("should be able to set the cache size", () => {
+        // [START fs_setup_cache]
+        firebase.firestore().settings({
+            cacheSizeBytes: firebase.firestore.CACHE_SIZE_UNLIMITED
+        });
+        // [END fs_setup_cache]
+    });
+
     it("should be initializable with persistence", () => {
       firebase.initializeApp({
         apiKey: '### FIREBASE API KEY ###',
@@ -33,14 +41,6 @@ describe("firestore", () => {
         });
       // Subsequent queries will use persistence, if it was enabled successfully
       // [END initialize_persistence]
-    });
-
-    it("should be able to set the cache size", () => {
-        // [START fs_setup_cache]
-        firebase.firestore().settings({
-            cacheSizeBytes: firebase.firestore.CACHE_SIZE_UNLIMITED
-        });
-        // [END fs_setup_cache]
     });
 
     it("should be able to enable/disable network", () => {


### PR DESCRIPTION
Fix mocha tests. Bump version to pick up newer methods. Run cache size test earlier to fix this error:

> FirebaseError: Firestore has already been started and its settings can no longer be changed. You can only call settings() before calling any other methods on a Firestore object.
