### PR TITLE
Fix sample data "regions" field typo

### DIFF
--- a/firestore/test.firestore.js
+++ b/firestore/test.firestore.js
@@ -868,7 +868,7 @@ describe("firestore", () => {
                 // [END in_filter]
 
                 // [START in_filter_with_array]
-                citiesRef.where('region', 'in',
+                citiesRef.where('regions', 'in',
                     [['west_coast', 'east_coast']]);
                 // [END in_filter_with_array]
             });


### PR DESCRIPTION
The [sample data](https://github.com/firebase/snippets-web/blob/master/firestore/test.firestore.js#L395) shows the field is named "regions", not "region"