### PR TITLE
Use consistent auth token variable

### DIFF
--- a/installations/index.js
+++ b/installations/index.js
@@ -24,9 +24,9 @@ async function getInstallationId() {
 async function getAuthenticationToken() {
   try {
     // [START get_auth_token]
-    const authToken = await firebase.installations()
+    const installationToken = await firebase.installations()
         .getToken(/* forceRefresh */ true);
-    console.log(authToken);
+    console.log(installationToken);
     // [END get_auth_token]
   } catch (err) {
     console.error('Unable to get auth token: ', err);


### PR DESCRIPTION
Other snippets for installations auth token is called `installationToken` using that here instead.