### PR TITLE
Fix geofire meters / km mixup

### DIFF
--- a/firestore-next/test.solution-geoqueries.js
+++ b/firestore-next/test.solution-geoqueries.js
@@ -35,12 +35,12 @@ async function queryHashes(done) {
 
   // Find cities within 50km of London
   const center = [51.5074, 0.1278];
-  const radiusInKm = 50;
+  const radiusInM = 50 * 1000;
 
   // Each item in 'bounds' represents a startAt/endAt pair. We have to issue
   // a separate query for each pair. There can be up to 9 pairs of bounds
   // depending on overlap, but in most cases there are 4.
-  const bounds = geofire.geohashQueryBounds(center, radiusInKm);
+  const bounds = geofire.geohashQueryBounds(center, radiusInM);
   const promises = [];
   for (const b of bounds) {
     const q = query(
@@ -63,8 +63,9 @@ async function queryHashes(done) {
 
       // We have to filter out a few false positives due to GeoHash
       // accuracy, but most will match
-      const distance = geofire.distanceBetween([lat, lng], center);
-      if (distance <= radiusInKm) {
+      const distanceInKm = geofire.distanceBetween([lat, lng], center);
+      const distanceInM = distanceInKm * 1000;
+      if (distanceInM <= radiusInM) {
         matchingDocs.push(doc);
       }
     }

--- a/firestore/test.solution-geoqueries.js
+++ b/firestore/test.solution-geoqueries.js
@@ -35,12 +35,12 @@ function queryHashes(done) {
   // [START fs_geo_query_hashes]
   // Find cities within 50km of London
   const center = [51.5074, 0.1278];
-  const radiusInKm = 50;
+  const radiusInM = 50 * 1000;
 
   // Each item in 'bounds' represents a startAt/endAt pair. We have to issue
   // a separate query for each pair. There can be up to 9 pairs of bounds
   // depending on overlap, but in most cases there are 4.
-  const bounds = geofire.geohashQueryBounds(center, radiusInKm);
+  const bounds = geofire.geohashQueryBounds(center, radiusInM);
   const promises = [];
   for (const b of bounds) {
     const q = db.collection('cities')
@@ -62,8 +62,9 @@ function queryHashes(done) {
 
         // We have to filter out a few false positives due to GeoHash
         // accuracy, but most will match
-        const distance = geofire.distanceBetween([lat, lng], center);
-        if (distance <= radiusInKm) {
+        const distanceInKm = geofire.distanceBetween([lat, lng], center);
+        const distanceInM = distanceInKm * 1000;
+        if (distanceInM <= radiusInM) {
           matchingDocs.push(doc);
         }
       }

--- a/firestore/test.solution-geoqueries.js
+++ b/firestore/test.solution-geoqueries.js
@@ -10,7 +10,6 @@ var db;
 
 function addHash(done) {
   // [START fs_geo_add_hash]
-
   // Compute the GeoHash for a lat/lng point
   const lat = 51.5074;
   const lng = 0.1278;

--- a/snippets/firestore-next/test-solution-geoqueries/fs_geo_query_hashes.js
+++ b/snippets/firestore-next/test-solution-geoqueries/fs_geo_query_hashes.js
@@ -8,12 +8,12 @@ import { collection, query, orderBy, startAt, endAt, getDocs } from 'firebase/fi
 
 // Find cities within 50km of London
 const center = [51.5074, 0.1278];
-const radiusInKm = 50;
+const radiusInM = 50 * 1000;
 
 // Each item in 'bounds' represents a startAt/endAt pair. We have to issue
 // a separate query for each pair. There can be up to 9 pairs of bounds
 // depending on overlap, but in most cases there are 4.
-const bounds = geofire.geohashQueryBounds(center, radiusInKm);
+const bounds = geofire.geohashQueryBounds(center, radiusInM);
 const promises = [];
 for (const b of bounds) {
   const q = query(
@@ -36,8 +36,9 @@ for (const snap of snapshots) {
 
     // We have to filter out a few false positives due to GeoHash
     // accuracy, but most will match
-    const distance = geofire.distanceBetween([lat, lng], center);
-    if (distance <= radiusInKm) {
+    const distanceInKm = geofire.distanceBetween([lat, lng], center);
+    const distanceInM = distanceInKm * 1000;
+    if (distanceInM <= radiusInM) {
       matchingDocs.push(doc);
     }
   }


### PR DESCRIPTION
Looks like we have a `km` / `m` inconsistency.

Confirmation that `distanceBetween` is km:
```
$ node
> const geofire = require('geofire-common')
undefined
> const sf = [37.77, 122.42]
undefined
> const ny = [40.71, 74.00]
undefined
> geofire.distanceBetween(sf, ny)
4129.881115620339
```

Confirmation that `geohashQueryBounds` takes meters:
```
$ node
> const geofire = require('geofire-common')
undefined
> const sf = [37.77, -122.42]
undefined
> geofire.geohashQueryBounds(sf, 50000)
[ [ '9q8h', '9q8~' ],
  [ '9q9h', '9q9~' ],
  [ '9qb0', '9qbh' ],
  [ '9qc0', '9qch' ] ]
```

Using https://geohash.co I can see that `9q8h` is `37.35351563, -123.57421875` and if we enter that in Google Maps we can see it's ~50km outside of San Francisco:

![Screen Shot 2020-12-23 at 4 16 19 PM](https://user-images.githubusercontent.com/8466666/103016666-6159cb00-4510-11eb-85f9-f9eb67fd0a72.png)
