### PR TITLE
Update email.js

### DIFF
--- a/auth-next/custom.js
+++ b/auth-next/custom.js
@@ -17,8 +17,9 @@ function signInCustom() {
 
   const auth = getAuth(firebaseApp);
   signInWithCustomToken(auth, token)
-    .then((user) => {
+    .then((userCredential) => {
       // Signed in
+      const user = userCredential.user;
       // ...
     })
     .catch((error) => {

--- a/auth-next/email.js
+++ b/auth-next/email.js
@@ -18,8 +18,9 @@ function signInWithEmailPassword() {
 
   const auth = getAuth(firebaseApp);
   signInWithEmailAndPassword(auth, email, password)
-    .then((user) => {
+    .then((userCredential) => {
       // Signed in 
+      const user = userCredential.user;
       // ...
     })
     .catch((error) => {
@@ -38,8 +39,9 @@ function signUpWithEmailPassword() {
 
   const auth = getAuth(firebaseApp);
   createUserWithEmailAndPassword(auth, email, password)
-    .then((user) => {
+    .then((userCredential) => {
       // Signed in 
+      const user = userCredential.user;
       // ...
     })
     .catch((error) => {

--- a/auth/custom.js
+++ b/auth/custom.js
@@ -8,8 +8,9 @@ function signInCustom() {
   var token = "token123";
   // [START auth_sign_in_custom]
   firebase.auth().signInWithCustomToken(token)
-    .then((user) => {
+    .then((userCredential) => {
       // Signed in
+      var user = userCredential.user;
       // ...
     })
     .catch((error) => {

--- a/auth/email.js
+++ b/auth/email.js
@@ -11,7 +11,7 @@ function signInWithEmailPassword() {
   firebase.auth().signInWithEmailAndPassword(email, password)
     .then((userCredential) => {
       // Signed in
-      console.log(userCredential.user.uid);
+      var user = userCredential.user;
       // ...
     })
     .catch((error) => {
@@ -28,7 +28,7 @@ function signUpWithEmailPasswoerd() {
   firebase.auth().createUserWithEmailAndPassword(email, password)
     .then((userCredential) => {
       // Signed in 
-      console.log(userCredential.user.uid);
+      var user = userCredential.user;
       // ...
     })
     .catch((error) => {

--- a/auth/email.js
+++ b/auth/email.js
@@ -9,8 +9,9 @@ function signInWithEmailPassword() {
   var password = "hunter2";
   // [START auth_signin_password]
   firebase.auth().signInWithEmailAndPassword(email, password)
-    .then((user) => {
-      // Signed in 
+    .then((userCredential) => {
+      // Signed in
+      console.log(userCredential.user.uid);
       // ...
     })
     .catch((error) => {
@@ -25,8 +26,9 @@ function signUpWithEmailPasswoerd() {
   var password = "hunter2";
   // [START auth_signup_password]
   firebase.auth().createUserWithEmailAndPassword(email, password)
-    .then((user) => {
+    .then((userCredential) => {
       // Signed in 
+      console.log(userCredential.user.uid);
       // ...
     })
     .catch((error) => {

--- a/snippets/auth-next/custom/auth_sign_in_custom.js
+++ b/snippets/auth-next/custom/auth_sign_in_custom.js
@@ -8,8 +8,9 @@ import { getAuth, signInWithCustomToken } from "firebase/auth";
 
 const auth = getAuth(firebaseApp);
 signInWithCustomToken(auth, token)
-  .then((user) => {
+  .then((userCredential) => {
     // Signed in
+    const user = userCredential.user;
     // ...
   })
   .catch((error) => {

--- a/snippets/auth-next/email/auth_signin_password.js
+++ b/snippets/auth-next/email/auth_signin_password.js
@@ -8,8 +8,9 @@ import { getAuth, signInWithEmailAndPassword } from "firebase/auth";
 
 const auth = getAuth(firebaseApp);
 signInWithEmailAndPassword(auth, email, password)
-  .then((user) => {
+  .then((userCredential) => {
     // Signed in 
+    const user = userCredential.user;
     // ...
   })
   .catch((error) => {

--- a/snippets/auth-next/email/auth_signup_password.js
+++ b/snippets/auth-next/email/auth_signup_password.js
@@ -8,8 +8,9 @@ import { getAuth, createUserWithEmailAndPassword } from "firebase/auth";
 
 const auth = getAuth(firebaseApp);
 createUserWithEmailAndPassword(auth, email, password)
-  .then((user) => {
+  .then((userCredential) => {
     // Signed in 
+    const user = userCredential.user;
     // ...
   })
   .catch((error) => {


### PR DESCRIPTION
The promises for `signInWithEmailAndPassword` and `createUserWithEmailAndPassword` resolve with a `UserCredential` and not a user. Calling the parameter `user` is a left-over from the old (pre-5.0) SDK where it was an actual `FirebaseUser` object.

I renamed the parameter and added an example of how to access the UID, which is the most common action for developers after creating an account/signing in.

Context: https://stackoverflow.com/questions/65817351/did-firebase-createuserwithemailandpassword-change-the-return-value/65817541?noredirect=1#comment116371334_65817541