### PR TITLE
Simplify Firestore references

### DIFF
--- a/firestore-next/test.firestore.js
+++ b/firestore-next/test.firestore.js
@@ -204,9 +204,9 @@ describe("firestore", () => {
 
         it("should reference a specific document", () => {
             // [START doc_reference]
-            const { collection, doc } = require("firebase/firestore");
+            const { doc } = require("firebase/firestore");
 
-            const alovelaceDocumentRef = doc(collection(db, 'users'), 'alovelace');
+            const alovelaceDocumentRef = doc(db, 'users', 'alovelace');
             // [END doc_reference]
         });
 
@@ -228,18 +228,18 @@ describe("firestore", () => {
 
         it("should reference a document in a subcollection", () => {
             // [START subcollection_reference]
-            const { doc, collection } = require("firebase/firestore"); 
+            const { doc } = require("firebase/firestore"); 
 
-            const messageRef = doc(collection(doc(collection(db, "rooms"), "roomA"), "messages"), "message1");
+            const messageRef = doc(db, "rooms", "roomA", "messages", "message1");
             // [END subcollection_reference]
         });
 
         it("should set a document", async () => {
             // [START set_document]
-            const { doc, collection, setDoc } = require("firebase/firestore"); 
+            const { doc, setDoc } = require("firebase/firestore"); 
 
             // Add a new document in collection "cities"
-            await setDoc(doc(collection(db, "cities"), "LA"), {
+            await setDoc(doc(db, "cities", "LA"), {
               name: "Los Angeles",
               state: "CA",
               country: "USA"
@@ -249,19 +249,19 @@ describe("firestore", () => {
 
         it("should set document with a custom object converter", async () => {
             // [START set_custom_object]
-            const { doc, collection, setDoc } = require("firebase/firestore"); 
+            const { doc, setDoc } = require("firebase/firestore"); 
             
             // Set with cityConverter
-            const ref = doc(collection(db, "cities"), "LA").withConverter(cityConverter);
+            const ref = doc(db, "cities", "LA").withConverter(cityConverter);
             await setDoc(ref, new City("Los Angeles", "CA", "USA"));
             // [END set_custom_object]
         });
 
         it("should get document with a custom object converter", async () => {
             // [START get_custom_object]
-            const { doc, collection, getDoc} = require("firebase/firestore"); 
+            const { doc, getDoc} = require("firebase/firestore"); 
 
-            const ref = doc(collection(db, "cities"), "LA").withConverter(cityConverter);
+            const ref = doc(db, "cities", "LA").withConverter(cityConverter);
             const docSnap = await getDoc(ref);
             if (docSnap.exists()) {
               // Convert to City object
@@ -276,21 +276,21 @@ describe("firestore", () => {
 
         it("should support batch writes", async () => {
             // [START write_batch]
-            const { writeBatch, doc, collection } = require("firebase/firestore"); 
+            const { writeBatch, doc } = require("firebase/firestore"); 
 
             // Get a new write batch
             const batch = writeBatch(db);
 
             // Set the value of 'NYC'
-            const nycRef = doc(collection(db, "cities"), "NYC");
+            const nycRef = doc(db, "cities", "NYC");
             batch.set(nycRef, {name: "New York City"});
 
             // Update the population of 'SF'
-            const sfRef = doc(collection(db, "cities"), "SF");
+            const sfRef = doc(db, "cities", "SF");
             batch.update(sfRef, {"population": 1000000});
 
             // Delete the city 'LA'
-            const laRef = doc(collection(db, "cities"), "LA");
+            const laRef = doc(db, "cities", "LA");
             batch.delete(laRef);
 
             // Commit the batch
@@ -300,7 +300,7 @@ describe("firestore", () => {
 
         it("should set a document with every datatype #UNVERIFIED", async () => {
             // [START data_types]
-            const { doc, collection, setDoc, Timestamp } = require("firebase/firestore"); 
+            const { doc, setDoc, Timestamp } = require("firebase/firestore"); 
 
             const docData = {
                 stringExample: "Hello world!",
@@ -316,25 +316,25 @@ describe("firestore", () => {
                     }
                 }
             };
-            await setDoc(doc(collection(db, "data"), "one"), docData);
+            await setDoc(doc(db, "data", "one"), docData);
             // [END data_types]
         });
 
         it("should allow set with merge", async () => {
             // [START set_with_merge]
-            const { doc, collection, setDoc } = require("firebase/firestore"); 
+            const { doc, setDoc } = require("firebase/firestore"); 
 
-            const cityRef = doc(collection(db, 'cities'), 'BJ');
+            const cityRef = doc(db, 'cities', 'BJ');
             setDoc(cityRef, { capital: true }, { merge: true });
             // [END set_with_merge]
         });
 
         it("should update a document's nested fields #UNVERIFIED", async () => {
             // [START update_document_nested]
-            const { doc, collection, setDoc, updateDoc } = require("firebase/firestore"); 
+            const { doc, setDoc, updateDoc } = require("firebase/firestore"); 
 
             // Create an initial document to update.
-            const frankDocRef = doc(collection(db, "users"), "frank");
+            const frankDocRef = doc(db, "users", "frank");
             await setDoc(frankDocRef, {
                 name: "Frank",
                 favorites: { food: "Pizza", color: "Blue", subject: "recess" },
@@ -431,9 +431,9 @@ describe("firestore", () => {
             const data = {};
 
             // [START cities_document_set]
-            const { collection, doc, setDoc } = require("firebase/firestore"); 
+            const { doc, setDoc } = require("firebase/firestore"); 
 
-            await setDoc(doc(collection(db, "cities"), "new-city-id"), data);
+            await setDoc(doc(db, "cities", "new-city-id"), data);
             // [END cities_document_set]
         });
 
@@ -466,9 +466,9 @@ describe("firestore", () => {
         it("should update a document", async () => {
             const data = {};
             // [START update_document]
-            const { collection, doc, updateDoc } = require("firebase/firestore");
+            const { doc, updateDoc } = require("firebase/firestore");
 
-            const washingtonRef = doc(collection(db, "cities"), "DC");
+            const washingtonRef = doc(db, "cities", "DC");
 
             // Set the "capital" field of the city 'DC'
             await updateDoc(washingtonRef, {
@@ -479,9 +479,9 @@ describe("firestore", () => {
 
         it("should update an array field in a document", async () => {
             // [START update_document_array]
-            const { collection, doc, updateDoc, arrayUnion, arrayRemove } = require("firebase/firestore");
+            const { doc, updateDoc, arrayUnion, arrayRemove } = require("firebase/firestore");
 
-            const washingtonRef = doc(collection(db, "cities"), "DC");
+            const washingtonRef = doc(db, "cities", "DC");
 
             // Atomically add a new region to the "regions" array field.
             await updateDoc(washingtonRef, {
@@ -497,9 +497,9 @@ describe("firestore", () => {
 
         it("should update a document using numeric transforms", async () => {
             // [START update_document_increment]
-            const { collection, doc, updateDoc, increment } = require("firebase/firestore");
+            const { doc, updateDoc, increment } = require("firebase/firestore");
 
-            const washingtonRef = doc(collection(db, "cities"), "DC");
+            const washingtonRef = doc(db, "cities", "DC");
 
             // Atomically increment the population of the city by 50.
             await updateDoc(washingtonRef, {
@@ -510,16 +510,16 @@ describe("firestore", () => {
 
         it("should delete a document", async () => {
             // [START delete_document]
-            const { collection, doc, deleteDoc } = require("firebase/firestore");
+            const { doc, deleteDoc } = require("firebase/firestore");
 
-            await deleteDoc(doc(collection(db, "cities"), "DC"));
+            await deleteDoc(doc(db, "cities", "DC"));
             // [END delete_document]
         });
 
         it("should handle transactions", async () => {
-            const { collection, doc, setDoc } = require("firebase/firestore");
+            const { doc, setDoc } = require("firebase/firestore");
 
-            const sfDocRef = doc(collection(db, "cities"), "SF");
+            const sfDocRef = doc(db, "cities", "SF");
             await setDoc(sfDocRef, { population: 0 });
 
             // [START transaction]
@@ -544,10 +544,10 @@ describe("firestore", () => {
 
         it("should handle transaction which bubble out data", async () => {
             // [START transaction_promise]
-            const { collection, doc, runTransaction } = require("firebase/firestore");
+            const { doc, runTransaction } = require("firebase/firestore");
 
             // Create a reference to the SF doc.
-            const sfDocRef = doc(collection(db, "cities"), "SF");
+            const sfDocRef = doc(db, "cities", "SF");
 
             try {
               const newPopulation = await runTransaction(db, async (transaction) => {
@@ -574,9 +574,9 @@ describe("firestore", () => {
 
         it("should get a single document", async () => {
             // [START get_document]
-            const { collection, doc, getDoc } = require("firebase/firestore");
+            const { doc, getDoc } = require("firebase/firestore");
 
-            const docRef = doc(collection(db, "cities"), "SF");
+            const docRef = doc(db, "cities", "SF");
             const docSnap = await getDoc(docRef);
 
             if (docSnap.exists()) {
@@ -590,9 +590,9 @@ describe("firestore", () => {
 
         it("should get a document with options", async () => {
             // [START get_document_options]
-            const { collection, doc, getDocFromCache } = require("firebase/firestore");
+            const { doc, getDocFromCache } = require("firebase/firestore");
 
-            const docRef = doc(collection(db, "cities"), "SF");
+            const docRef = doc(db, "cities", "SF");
 
             // Get a document, forcing the SDK to fetch from the offline cache.
             try {
@@ -609,9 +609,9 @@ describe("firestore", () => {
 
         it("should listen on a single document", (done) => {
             // [START listen_document]
-            const { collection, doc, onSnapshot } = require("firebase/firestore");
+            const { doc, onSnapshot } = require("firebase/firestore");
 
-            const unsub = onSnapshot(doc(collection(db, "cities"), "SF"), (doc) => {
+            const unsub = onSnapshot(doc(db, "cities", "SF"), (doc) => {
                 console.log("Current data: ", doc.data());
             });
             // [END listen_document]
@@ -624,9 +624,9 @@ describe("firestore", () => {
 
         it("should listen on a single document with metadata", (done) => {
             // [START listen_document_local]
-            const { collection, doc, onSnapshot } = require("firebase/firestore");
+            const { doc, onSnapshot } = require("firebase/firestore");
 
-            const unsub = onSnapshot(doc(collection(db, "cities"), "SF"), (doc) => {
+            const unsub = onSnapshot(doc(db, "cities", "SF"), (doc) => {
               const source = doc.metadata.hasPendingWrites ? "Local" : "Server";
               console.log(source, " data: ", doc.data());
             });
@@ -640,10 +640,10 @@ describe("firestore", () => {
 
         it("should listen on a single document with options #UNVERIFIED", (done) => {
             // [START listen_with_metadata]
-            const { collection, doc, onSnapshot } = require("firebase/firestore");
+            const { doc, onSnapshot } = require("firebase/firestore");
 
             const unsub = onSnapshot(
-              doc(collection(db, "cities"), "SF"), 
+              doc(db, "cities", "SF"), 
               { includeMetadataChanges: true }, 
               (doc) => {
                 // ...
@@ -761,9 +761,9 @@ describe("firestore", () => {
         it("should update a document with server timestamp", async () => {
             async function update() {
                 // [START update_with_server_timestamp]
-                const { collection, updateDoc, serverTimestamp } = require("firebase/firestore");
+                const { updateDoc, serverTimestamp } = require("firebase/firestore");
 
-                const docRef = doc(collection(db, 'objects'), 'some-id');
+                const docRef = doc(db, 'objects', 'some-id');
 
                 // Update the timestamp field with the value from the server
                 const updateTimestamp = await updateDoc(docRef, {
@@ -774,21 +774,21 @@ describe("firestore", () => {
                 return updateTimestamp;
             }
 
-            const { collection, doc, setDoc } = require("firebase/firestore");
+            const { doc, setDoc } = require("firebase/firestore");
 
-            await setDoc(doc(collection(db, 'objects'), 'some-id'), {});
+            await setDoc(doc(db, 'objects', 'some-id'), {});
             await update();
             console.log('Document updated with server timestamp');
         });
 
         it("should use options to control server timestamp resolution", async () => {
           // [START server_timestamp_resolution_options]
-          const { collection, doc, updateDoc, serverTimestamp, onSnapshot } = require("firebase/firestore");
+          const { doc, updateDoc, serverTimestamp, onSnapshot } = require("firebase/firestore");
           // Perform an update followed by an immediate read without
           // waiting for the update to complete. Due to the snapshot
           // options we will get two results: one with an estimate
           // timestamp and one with the resolved server timestamp.
-          const docRef = doc(collection(db, 'objects'), 'some-id');
+          const docRef = doc(db, 'objects', 'some-id');
           updateDoc(docRef, {
               timestamp: serverTimestamp()
           });
@@ -808,9 +808,9 @@ describe("firestore", () => {
         it("should delete a document field", async () => {
             async function update() {
               // [START update_delete_field]
-              const { doc, collection, updateDoc, deleteField } = require("firebase/firestore");
+              const { doc, updateDoc, deleteField } = require("firebase/firestore");
 
-              const cityRef = doc(collection(db, 'cities'), 'BJ');
+              const cityRef = doc(db, 'cities', 'BJ');
 
               // Remove the 'capital' field from the document
               await updateDoc(cityRef, {
@@ -819,9 +819,9 @@ describe("firestore", () => {
               // [END update_delete_field]
             }
 
-            const { doc, collection, setDoc } = require("firebase/firestore");
+            const { doc, setDoc } = require("firebase/firestore");
 
-            await setDoc(doc(collection(db,'cities'), 'BJ'), { capital: true });
+            await setDoc(doc(db, 'cities', 'BJ'), { capital: true });
             await update();
         });
 
@@ -1099,43 +1099,43 @@ describe("firestore", () => {
                 const citiesRef = collection(db, 'cities');
 
                 await Promise.all([
-                    setDoc(doc(collection(doc(citiesRef, 'SF'), 'landmarks')), {
+                    setDoc(doc(citiesRef, 'SF', 'landmarks'), {
                         name: 'Golden Gate Bridge',
                         type: 'bridge'
                     }),
-                    setDoc(doc(collection(doc(citiesRef, 'SF'), 'landmarks')), {
+                    setDoc(doc(citiesRef, 'SF', 'landmarks'), {
                         name: 'Legion of Honor',
                         type: 'museum'
                     }),
-                    setDoc(doc(collection(doc(citiesRef, 'LA'), 'landmarks')), {
+                    setDoc(doc(citiesRef, 'LA', 'landmarks'), {
                         name: 'Griffith Park',
                         type: 'park'
                     }),
-                    setDoc(doc(collection(doc(citiesRef, 'LA'), 'landmarks')), {
+                    setDoc(doc(citiesRef, 'LA', 'landmarks'), {
                         name: 'The Getty',
                         type: 'museum'
                     }),
-                    setDoc(doc(collection(doc(citiesRef, 'DC'), 'landmarks')), {
+                    setDoc(doc(citiesRef, 'DC', 'landmarks'), {
                         name: 'Lincoln Memorial',
                         type: 'memorial'
                     }),
-                    setDoc(doc(collection(doc(citiesRef, 'DC'), 'landmarks')), {
+                    setDoc(doc(citiesRef, 'DC', 'landmarks'), {
                         name: 'National Air and Space Museum',
                         type: 'museum'
                     }),
-                    setDoc(doc(collection(doc(citiesRef, 'TOK'), 'landmarks')), {
+                    setDoc(doc(citiesRef, 'TOK', 'landmarks'), {
                         name: 'Ueno Park',
                         type: 'park'
                     }),
-                    setDoc(doc(collection(doc(citiesRef, 'TOK'), 'landmarks')), {
+                    setDoc(doc(citiesRef, 'TOK', 'landmarks'), {
                         name: 'National Museum of Nature and Science',
                         type: 'museum'
                     }),
-                    setDoc(doc(collection(doc(citiesRef, 'BJ'), 'landmarks')), {
+                    setDoc(doc(citiesRef, 'BJ', 'landmarks'), {
                         name: 'Jingshan Park',
                         type: 'park'
                     }),
-                    setDoc(doc(collection(doc(citiesRef, 'BJ'), 'landmarks')), {
+                    setDoc(doc(citiesRef, 'BJ', 'landmarks'), {
                         name: 'Beijing Ancient Observatory',
                         type: 'museum'
                     })
@@ -1161,7 +1161,7 @@ describe("firestore", () => {
     describe("solution-aggregation", () => {
         it("should update a restaurant in a transaction #UNVERIFIED", async () => {
             // [START add_rating_transaction]
-            const { collection, doc, runTransaction} = require("firebase/firestore");  
+            const { collection, doc, runTransaction } = require("firebase/firestore");  
 
             async function addRating(restaurantRef, rating) {
                 // Create a reference for a new rating, for use inside the transaction
@@ -1193,7 +1193,7 @@ describe("firestore", () => {
 
             // Create document and add a rating
             const { setDoc } = require("firebase/firestore");
-            const ref = doc(collection(db, 'restaurants'), ('arinell-pizza'));
+            const ref = doc(db, 'restaurants', 'arinell-pizza');
             await setDoc(ref, {
                 name: 'Arinell Pizza',
                 avgRating: 4.63,

--- a/firestore-next/test.solution-aggregation.js
+++ b/firestore-next/test.solution-aggregation.js
@@ -27,15 +27,15 @@ describe("firestore-solution-arrays", () => {
       const app = initializeApp(config, "solution-arrays");
       db = getFirestore(app);
 
-      await setDoc(doc(collection(db, "restaurants"), "arinell-pizza"), arinellDoc);
+      await setDoc(doc(db, "restaurants", "arinell-pizza"), arinellDoc);
     });
 
     describe("solution-arrays", () => {
         it("should get a collection of ratings", async () => {
           // [START get_collection_ratings]
-          const { collection, doc, getDocs } = require("firebase/firestore");
+          const { collection, getDocs } = require("firebase/firestore");
 
-          const ratingsRef = collection(doc(collection(db, "restaurants"), "arinell-pizza"), "ratings");
+          const ratingsRef = collection(db, "restaurants", "arinell-pizza", "ratings");
           const ratingsDocs = await getDocs(ratingsRef);
           // [END get_collection_ratings]
         });

--- a/firestore-next/test.solution-counters.js
+++ b/firestore-next/test.solution-counters.js
@@ -8,7 +8,7 @@ let db;
 
 // [START create_counter]
 function createCounter(ref, num_shards) {
-    const { collection, doc, writeBatch } = require("firebase/firestore");
+    const { doc, writeBatch } = require("firebase/firestore");
 
     const batch = writeBatch(db);
 
@@ -17,7 +17,7 @@ function createCounter(ref, num_shards) {
 
     // Initialize each shard with count=0
     for (let i = 0; i < num_shards; i++) {
-        const shardRef = doc(collection(ref, 'shards'), i.toString());
+        const shardRef = doc(ref, 'shards', i.toString());
         batch.set(shardRef, { count: 0 });
     }
 
@@ -32,7 +32,7 @@ function incrementCounter(db, ref, num_shards) {
 
     // Select a shard of the counter at random
     const shardId = Math.floor(Math.random() * num_shards).toString();
-    const shardRef = doc(collection(ref, 'shards'), shardId);
+    const shardRef = doc(ref, 'shards', shardId);
 
     // Update count
     return updateDoc(shardRef, "count", increment(1));

--- a/snippets/firestore-next/test-firestore/add_rating_transaction.js
+++ b/snippets/firestore-next/test-firestore/add_rating_transaction.js
@@ -4,7 +4,7 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START add_rating_transaction_modular]
-import { collection, doc, runTransaction} from "firebase/firestore";  
+import { collection, doc, runTransaction } from "firebase/firestore";  
 
 async function addRating(restaurantRef, rating) {
     // Create a reference for a new rating, for use inside the transaction

--- a/snippets/firestore-next/test-firestore/cities_document_set.js
+++ b/snippets/firestore-next/test-firestore/cities_document_set.js
@@ -4,7 +4,7 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START cities_document_set_modular]
-import { collection, doc, setDoc } from "firebase/firestore"; 
+import { doc, setDoc } from "firebase/firestore"; 
 
-await setDoc(doc(collection(db, "cities"), "new-city-id"), data);
+await setDoc(doc(db, "cities", "new-city-id"), data);
 // [END cities_document_set_modular]

--- a/snippets/firestore-next/test-firestore/data_types.js
+++ b/snippets/firestore-next/test-firestore/data_types.js
@@ -4,7 +4,7 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START data_types_modular]
-import { doc, collection, setDoc, Timestamp } from "firebase/firestore"; 
+import { doc, setDoc, Timestamp } from "firebase/firestore"; 
 
 const docData = {
     stringExample: "Hello world!",
@@ -20,5 +20,5 @@ const docData = {
         }
     }
 };
-await setDoc(doc(collection(db, "data"), "one"), docData);
+await setDoc(doc(db, "data", "one"), docData);
 // [END data_types_modular]

--- a/snippets/firestore-next/test-firestore/delete_document.js
+++ b/snippets/firestore-next/test-firestore/delete_document.js
@@ -4,7 +4,7 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START delete_document_modular]
-import { collection, doc, deleteDoc } from "firebase/firestore";
+import { doc, deleteDoc } from "firebase/firestore";
 
-await deleteDoc(doc(collection(db, "cities"), "DC"));
+await deleteDoc(doc(db, "cities", "DC"));
 // [END delete_document_modular]

--- a/snippets/firestore-next/test-firestore/doc_reference.js
+++ b/snippets/firestore-next/test-firestore/doc_reference.js
@@ -4,7 +4,7 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START doc_reference_modular]
-import { collection, doc } from "firebase/firestore";
+import { doc } from "firebase/firestore";
 
-const alovelaceDocumentRef = doc(collection(db, 'users'), 'alovelace');
+const alovelaceDocumentRef = doc(db, 'users', 'alovelace');
 // [END doc_reference_modular]

--- a/snippets/firestore-next/test-firestore/fs_collection_group_query_data_setup.js
+++ b/snippets/firestore-next/test-firestore/fs_collection_group_query_data_setup.js
@@ -9,43 +9,43 @@ import { collection, doc, setDoc } from "firebase/firestore";
 const citiesRef = collection(db, 'cities');
 
 await Promise.all([
-    setDoc(doc(collection(doc(citiesRef, 'SF'), 'landmarks')), {
+    setDoc(doc(citiesRef, 'SF', 'landmarks'), {
         name: 'Golden Gate Bridge',
         type: 'bridge'
     }),
-    setDoc(doc(collection(doc(citiesRef, 'SF'), 'landmarks')), {
+    setDoc(doc(citiesRef, 'SF', 'landmarks'), {
         name: 'Legion of Honor',
         type: 'museum'
     }),
-    setDoc(doc(collection(doc(citiesRef, 'LA'), 'landmarks')), {
+    setDoc(doc(citiesRef, 'LA', 'landmarks'), {
         name: 'Griffith Park',
         type: 'park'
     }),
-    setDoc(doc(collection(doc(citiesRef, 'LA'), 'landmarks')), {
+    setDoc(doc(citiesRef, 'LA', 'landmarks'), {
         name: 'The Getty',
         type: 'museum'
     }),
-    setDoc(doc(collection(doc(citiesRef, 'DC'), 'landmarks')), {
+    setDoc(doc(citiesRef, 'DC', 'landmarks'), {
         name: 'Lincoln Memorial',
         type: 'memorial'
     }),
-    setDoc(doc(collection(doc(citiesRef, 'DC'), 'landmarks')), {
+    setDoc(doc(citiesRef, 'DC', 'landmarks'), {
         name: 'National Air and Space Museum',
         type: 'museum'
     }),
-    setDoc(doc(collection(doc(citiesRef, 'TOK'), 'landmarks')), {
+    setDoc(doc(citiesRef, 'TOK', 'landmarks'), {
         name: 'Ueno Park',
         type: 'park'
     }),
-    setDoc(doc(collection(doc(citiesRef, 'TOK'), 'landmarks')), {
+    setDoc(doc(citiesRef, 'TOK', 'landmarks'), {
         name: 'National Museum of Nature and Science',
         type: 'museum'
     }),
-    setDoc(doc(collection(doc(citiesRef, 'BJ'), 'landmarks')), {
+    setDoc(doc(citiesRef, 'BJ', 'landmarks'), {
         name: 'Jingshan Park',
         type: 'park'
     }),
-    setDoc(doc(collection(doc(citiesRef, 'BJ'), 'landmarks')), {
+    setDoc(doc(citiesRef, 'BJ', 'landmarks'), {
         name: 'Beijing Ancient Observatory',
         type: 'museum'
     })

--- a/snippets/firestore-next/test-firestore/get_custom_object.js
+++ b/snippets/firestore-next/test-firestore/get_custom_object.js
@@ -4,9 +4,9 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START get_custom_object_modular]
-import { doc, collection, getDoc} from "firebase/firestore"; 
+import { doc, getDoc} from "firebase/firestore"; 
 
-const ref = doc(collection(db, "cities"), "LA").withConverter(cityConverter);
+const ref = doc(db, "cities", "LA").withConverter(cityConverter);
 const docSnap = await getDoc(ref);
 if (docSnap.exists()) {
   // Convert to City object

--- a/snippets/firestore-next/test-firestore/get_document.js
+++ b/snippets/firestore-next/test-firestore/get_document.js
@@ -4,9 +4,9 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START get_document_modular]
-import { collection, doc, getDoc } from "firebase/firestore";
+import { doc, getDoc } from "firebase/firestore";
 
-const docRef = doc(collection(db, "cities"), "SF");
+const docRef = doc(db, "cities", "SF");
 const docSnap = await getDoc(docRef);
 
 if (docSnap.exists()) {

--- a/snippets/firestore-next/test-firestore/get_document_options.js
+++ b/snippets/firestore-next/test-firestore/get_document_options.js
@@ -4,9 +4,9 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START get_document_options_modular]
-import { collection, doc, getDocFromCache } from "firebase/firestore";
+import { doc, getDocFromCache } from "firebase/firestore";
 
-const docRef = doc(collection(db, "cities"), "SF");
+const docRef = doc(db, "cities", "SF");
 
 // Get a document, forcing the SDK to fetch from the offline cache.
 try {

--- a/snippets/firestore-next/test-firestore/listen_document.js
+++ b/snippets/firestore-next/test-firestore/listen_document.js
@@ -4,9 +4,9 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START listen_document_modular]
-import { collection, doc, onSnapshot } from "firebase/firestore";
+import { doc, onSnapshot } from "firebase/firestore";
 
-const unsub = onSnapshot(doc(collection(db, "cities"), "SF"), (doc) => {
+const unsub = onSnapshot(doc(db, "cities", "SF"), (doc) => {
     console.log("Current data: ", doc.data());
 });
 // [END listen_document_modular]

--- a/snippets/firestore-next/test-firestore/listen_document_local.js
+++ b/snippets/firestore-next/test-firestore/listen_document_local.js
@@ -4,9 +4,9 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START listen_document_local_modular]
-import { collection, doc, onSnapshot } from "firebase/firestore";
+import { doc, onSnapshot } from "firebase/firestore";
 
-const unsub = onSnapshot(doc(collection(db, "cities"), "SF"), (doc) => {
+const unsub = onSnapshot(doc(db, "cities", "SF"), (doc) => {
   const source = doc.metadata.hasPendingWrites ? "Local" : "Server";
   console.log(source, " data: ", doc.data());
 });

--- a/snippets/firestore-next/test-firestore/listen_with_metadata.js
+++ b/snippets/firestore-next/test-firestore/listen_with_metadata.js
@@ -4,10 +4,10 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START listen_with_metadata_modular]
-import { collection, doc, onSnapshot } from "firebase/firestore";
+import { doc, onSnapshot } from "firebase/firestore";
 
 const unsub = onSnapshot(
-  doc(collection(db, "cities"), "SF"), 
+  doc(db, "cities", "SF"), 
   { includeMetadataChanges: true }, 
   (doc) => {
     // ...

--- a/snippets/firestore-next/test-firestore/server_timestamp_resolution_options.js
+++ b/snippets/firestore-next/test-firestore/server_timestamp_resolution_options.js
@@ -4,12 +4,12 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START server_timestamp_resolution_options_modular]
-import { collection, doc, updateDoc, serverTimestamp, onSnapshot } from "firebase/firestore";
+import { doc, updateDoc, serverTimestamp, onSnapshot } from "firebase/firestore";
 // Perform an update followed by an immediate read without
 // waiting for the update to complete. Due to the snapshot
 // options we will get two results: one with an estimate
 // timestamp and one with the resolved server timestamp.
-const docRef = doc(collection(db, 'objects'), 'some-id');
+const docRef = doc(db, 'objects', 'some-id');
 updateDoc(docRef, {
     timestamp: serverTimestamp()
 });

--- a/snippets/firestore-next/test-firestore/set_custom_object.js
+++ b/snippets/firestore-next/test-firestore/set_custom_object.js
@@ -4,9 +4,9 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START set_custom_object_modular]
-import { doc, collection, setDoc } from "firebase/firestore"; 
+import { doc, setDoc } from "firebase/firestore"; 
 
 // Set with cityConverter
-const ref = doc(collection(db, "cities"), "LA").withConverter(cityConverter);
+const ref = doc(db, "cities", "LA").withConverter(cityConverter);
 await setDoc(ref, new City("Los Angeles", "CA", "USA"));
 // [END set_custom_object_modular]

--- a/snippets/firestore-next/test-firestore/set_document.js
+++ b/snippets/firestore-next/test-firestore/set_document.js
@@ -4,10 +4,10 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START set_document_modular]
-import { doc, collection, setDoc } from "firebase/firestore"; 
+import { doc, setDoc } from "firebase/firestore"; 
 
 // Add a new document in collection "cities"
-await setDoc(doc(collection(db, "cities"), "LA"), {
+await setDoc(doc(db, "cities", "LA"), {
   name: "Los Angeles",
   state: "CA",
   country: "USA"

--- a/snippets/firestore-next/test-firestore/set_with_merge.js
+++ b/snippets/firestore-next/test-firestore/set_with_merge.js
@@ -4,8 +4,8 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START set_with_merge_modular]
-import { doc, collection, setDoc } from "firebase/firestore"; 
+import { doc, setDoc } from "firebase/firestore"; 
 
-const cityRef = doc(collection(db, 'cities'), 'BJ');
+const cityRef = doc(db, 'cities', 'BJ');
 setDoc(cityRef, { capital: true }, { merge: true });
 // [END set_with_merge_modular]

--- a/snippets/firestore-next/test-firestore/subcollection_reference.js
+++ b/snippets/firestore-next/test-firestore/subcollection_reference.js
@@ -4,7 +4,7 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START subcollection_reference_modular]
-import { doc, collection } from "firebase/firestore"; 
+import { doc } from "firebase/firestore"; 
 
-const messageRef = doc(collection(doc(collection(db, "rooms"), "roomA"), "messages"), "message1");
+const messageRef = doc(db, "rooms", "roomA", "messages", "message1");
 // [END subcollection_reference_modular]

--- a/snippets/firestore-next/test-firestore/transaction_promise.js
+++ b/snippets/firestore-next/test-firestore/transaction_promise.js
@@ -4,10 +4,10 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START transaction_promise_modular]
-import { collection, doc, runTransaction } from "firebase/firestore";
+import { doc, runTransaction } from "firebase/firestore";
 
 // Create a reference to the SF doc.
-const sfDocRef = doc(collection(db, "cities"), "SF");
+const sfDocRef = doc(db, "cities", "SF");
 
 try {
   const newPopulation = await runTransaction(db, async (transaction) => {

--- a/snippets/firestore-next/test-firestore/update_delete_field.js
+++ b/snippets/firestore-next/test-firestore/update_delete_field.js
@@ -4,9 +4,9 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START update_delete_field_modular]
-import { doc, collection, updateDoc, deleteField } from "firebase/firestore";
+import { doc, updateDoc, deleteField } from "firebase/firestore";
 
-const cityRef = doc(collection(db, 'cities'), 'BJ');
+const cityRef = doc(db, 'cities', 'BJ');
 
 // Remove the 'capital' field from the document
 await updateDoc(cityRef, {

--- a/snippets/firestore-next/test-firestore/update_document.js
+++ b/snippets/firestore-next/test-firestore/update_document.js
@@ -4,9 +4,9 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START update_document_modular]
-import { collection, doc, updateDoc } from "firebase/firestore";
+import { doc, updateDoc } from "firebase/firestore";
 
-const washingtonRef = doc(collection(db, "cities"), "DC");
+const washingtonRef = doc(db, "cities", "DC");
 
 // Set the "capital" field of the city 'DC'
 await updateDoc(washingtonRef, {

--- a/snippets/firestore-next/test-firestore/update_document_array.js
+++ b/snippets/firestore-next/test-firestore/update_document_array.js
@@ -4,9 +4,9 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START update_document_array_modular]
-import { collection, doc, updateDoc, arrayUnion, arrayRemove } from "firebase/firestore";
+import { doc, updateDoc, arrayUnion, arrayRemove } from "firebase/firestore";
 
-const washingtonRef = doc(collection(db, "cities"), "DC");
+const washingtonRef = doc(db, "cities", "DC");
 
 // Atomically add a new region to the "regions" array field.
 await updateDoc(washingtonRef, {

--- a/snippets/firestore-next/test-firestore/update_document_increment.js
+++ b/snippets/firestore-next/test-firestore/update_document_increment.js
@@ -4,9 +4,9 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START update_document_increment_modular]
-import { collection, doc, updateDoc, increment } from "firebase/firestore";
+import { doc, updateDoc, increment } from "firebase/firestore";
 
-const washingtonRef = doc(collection(db, "cities"), "DC");
+const washingtonRef = doc(db, "cities", "DC");
 
 // Atomically increment the population of the city by 50.
 await updateDoc(washingtonRef, {

--- a/snippets/firestore-next/test-firestore/update_document_nested.js
+++ b/snippets/firestore-next/test-firestore/update_document_nested.js
@@ -4,10 +4,10 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START update_document_nested_modular]
-import { doc, collection, setDoc, updateDoc } from "firebase/firestore"; 
+import { doc, setDoc, updateDoc } from "firebase/firestore"; 
 
 // Create an initial document to update.
-const frankDocRef = doc(collection(db, "users"), "frank");
+const frankDocRef = doc(db, "users", "frank");
 await setDoc(frankDocRef, {
     name: "Frank",
     favorites: { food: "Pizza", color: "Blue", subject: "recess" },

--- a/snippets/firestore-next/test-firestore/update_with_server_timestamp.js
+++ b/snippets/firestore-next/test-firestore/update_with_server_timestamp.js
@@ -4,9 +4,9 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START update_with_server_timestamp_modular]
-import { collection, updateDoc, serverTimestamp } from "firebase/firestore";
+import { updateDoc, serverTimestamp } from "firebase/firestore";
 
-const docRef = doc(collection(db, 'objects'), 'some-id');
+const docRef = doc(db, 'objects', 'some-id');
 
 // Update the timestamp field with the value from the server
 const updateTimestamp = await updateDoc(docRef, {

--- a/snippets/firestore-next/test-firestore/write_batch.js
+++ b/snippets/firestore-next/test-firestore/write_batch.js
@@ -4,21 +4,21 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START write_batch_modular]
-import { writeBatch, doc, collection } from "firebase/firestore"; 
+import { writeBatch, doc } from "firebase/firestore"; 
 
 // Get a new write batch
 const batch = writeBatch(db);
 
 // Set the value of 'NYC'
-const nycRef = doc(collection(db, "cities"), "NYC");
+const nycRef = doc(db, "cities", "NYC");
 batch.set(nycRef, {name: "New York City"});
 
 // Update the population of 'SF'
-const sfRef = doc(collection(db, "cities"), "SF");
+const sfRef = doc(db, "cities", "SF");
 batch.update(sfRef, {"population": 1000000});
 
 // Delete the city 'LA'
-const laRef = doc(collection(db, "cities"), "LA");
+const laRef = doc(db, "cities", "LA");
 batch.delete(laRef);
 
 // Commit the batch

--- a/snippets/firestore-next/test-solution-aggregation/get_collection_ratings.js
+++ b/snippets/firestore-next/test-solution-aggregation/get_collection_ratings.js
@@ -4,8 +4,8 @@
 // To make edits to the snippets in this file, please edit the source
 
 // [START get_collection_ratings_modular]
-import { collection, doc, getDocs } from "firebase/firestore";
+import { collection, getDocs } from "firebase/firestore";
 
-const ratingsRef = collection(doc(collection(db, "restaurants"), "arinell-pizza"), "ratings");
+const ratingsRef = collection(db, "restaurants", "arinell-pizza", "ratings");
 const ratingsDocs = await getDocs(ratingsRef);
 // [END get_collection_ratings_modular]

--- a/snippets/firestore-next/test-solution-counters/create_counter.js
+++ b/snippets/firestore-next/test-solution-counters/create_counter.js
@@ -5,7 +5,7 @@
 
 // [START create_counter_modular]
 function createCounter(ref, num_shards) {
-    import { collection, doc, writeBatch } from "firebase/firestore";
+    import { doc, writeBatch } from "firebase/firestore";
 
     const batch = writeBatch(db);
 
@@ -14,7 +14,7 @@ function createCounter(ref, num_shards) {
 
     // Initialize each shard with count=0
     for (let i = 0; i < num_shards; i++) {
-        const shardRef = doc(collection(ref, 'shards'), i.toString());
+        const shardRef = doc(ref, 'shards', i.toString());
         batch.set(shardRef, { count: 0 });
     }
 

--- a/snippets/firestore-next/test-solution-counters/increment_counter.js
+++ b/snippets/firestore-next/test-solution-counters/increment_counter.js
@@ -9,7 +9,7 @@ function incrementCounter(db, ref, num_shards) {
 
     // Select a shard of the counter at random
     const shardId = Math.floor(Math.random() * num_shards).toString();
-    const shardRef = doc(collection(ref, 'shards'), shardId);
+    const shardRef = doc(ref, 'shards', shardId);
 
     // Update count
     return updateDoc(shardRef, "count", increment(1));


### PR DESCRIPTION
Remove excessive `doc(collection` nesting

cc @schmidt-sebastian 