### PR TITLE
SDK v9.0.0-beta.3

### DIFF
--- a/analytics-next/package.json
+++ b/analytics-next/package.json
@@ -6,6 +6,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "firebase": "^9.0.0-beta.1"
+    "firebase": "^9.0.0-beta.3"
   }
 }

--- a/auth-next/package.json
+++ b/auth-next/package.json
@@ -6,6 +6,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "firebase": "^9.0.0-beta.1"
+    "firebase": "^9.0.0-beta.3"
   }
 }

--- a/database-next/package.json
+++ b/database-next/package.json
@@ -6,6 +6,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "firebase": "^9.0.0-beta.1"
+    "firebase": "^9.0.0-beta.3"
   }
 }

--- a/firebaseapp-next/package.json
+++ b/firebaseapp-next/package.json
@@ -6,6 +6,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "firebase": "^9.0.0-beta.1"
+    "firebase": "^9.0.0-beta.3"
   }
 }

--- a/firestore-next/package.json
+++ b/firestore-next/package.json
@@ -6,7 +6,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "firebase": "^9.0.0-beta.1",
+    "firebase": "^9.0.0-beta.3",
     "geofire-common": "^5.1.0"
   },
   "devDependencies": {

--- a/functions-next/package.json
+++ b/functions-next/package.json
@@ -6,6 +6,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "firebase": "^9.0.0-beta.1"
+    "firebase": "^9.0.0-beta.3"
   }
 }

--- a/messaging-next/package.json
+++ b/messaging-next/package.json
@@ -6,6 +6,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "firebase": "^9.0.0-beta.1"
+    "firebase": "^9.0.0-beta.3"
   }
 }

--- a/perf-next/package.json
+++ b/perf-next/package.json
@@ -6,6 +6,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "firebase": "^9.0.0-beta.1"
+    "firebase": "^9.0.0-beta.3"
   }
 }

--- a/remoteconfig-next/package.json
+++ b/remoteconfig-next/package.json
@@ -6,6 +6,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "firebase": "^9.0.0-beta.1"
+    "firebase": "^9.0.0-beta.3"
   }
 }

--- a/storage-next/package.json
+++ b/storage-next/package.json
@@ -6,6 +6,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "firebase": "^9.0.0-beta.1"
+    "firebase": "^9.0.0-beta.3"
   }
 }


### PR DESCRIPTION
The `ncu` script that we use for updates doesn't include `beta` versions by default so we have to do this manually.