### PR TITLE
Update commented out code with useDeviceLanguage to modular api

### DIFF
--- a/auth-next/index.js
+++ b/auth-next/index.js
@@ -87,7 +87,8 @@ function setLanguageCode() {
   const auth = getAuth();
   auth.languageCode = 'it';
   // To apply the default browser preference instead of explicitly setting it.
-  // firebase.auth().useDeviceLanguage();
+  // const { useDeviceLanguage } = require("firebase/auth");
+  // useDeviceLanguage(auth);
   // [END auth_set_language_code]
 }
 


### PR DESCRIPTION
Hi, the commented out code example for `useDeviceLanguage` used the old API, this PR updates it to the new modular API