### PR TITLE
update download-files to be consistent

### DIFF
--- a/snippets/storage-next/download-files/storage_download_via_url.js
+++ b/snippets/storage-next/download-files/storage_download_via_url.js
@@ -8,7 +8,9 @@
 import { getStorage, ref, getDownloadURL } from "firebase/storage";
 
 const storage = getStorage();
-getDownloadURL(ref(storage, 'images/stars.jpg'))
+const starsRef = ref(storage, 'images/stars.jpg');
+
+getDownloadURL(starsRef)
   .then((url) => {
     // `url` is the download URL for 'images/stars.jpg'
 

--- a/storage-next/download-files.js
+++ b/storage-next/download-files.js
@@ -23,7 +23,9 @@ function downloadViaUrl() {
   const { getStorage, ref, getDownloadURL } = require("firebase/storage");
 
   const storage = getStorage();
-  getDownloadURL(ref(storage, 'images/stars.jpg'))
+  const starsRef = ref(storage, 'images/stars.jpg');
+
+  getDownloadURL(starsRef)
     .then((url) => {
       // `url` is the download URL for 'images/stars.jpg'
     


### PR DESCRIPTION
In all Storage docs, the reference gets stored into a variable, which is then used later. Updating this to do that as well.