### PR TITLE
Show how to create a credential

### DIFF
--- a/snippets/auth-next/manage/auth_reauth_with_credential.js
+++ b/snippets/auth-next/manage/auth_reauth_with_credential.js
@@ -5,12 +5,16 @@
 // 'npm run snippets'.
 
 // [START auth_reauth_with_credential_modular]
-import { getAuth, reauthenticateWithCredential } from "firebase/auth";
+import { getAuth, reauthenticateWithCredential, EmailAuthProvider} from "firebase/auth";
 
 const auth = getAuth();
 const user = auth.currentUser;
 
-// TODO(you): prompt the user to re-provide their sign-in credentials
+// prompt the user to re-provide their sign-in credentials
+const promptForCredentials = (userProvidedPassword) => {
+  return EmailAuthProvider.credential(user.email, userProvidedPassword);
+}
+
 const credential = promptForCredentials();
 
 reauthenticateWithCredential(user, credential).then(() => {


### PR DESCRIPTION
Getting a credential for reauthentication is a real head-scratcher since Firebase documentation does not clarify how to do it. Many people [complain about it:](https://stackoverflow.com/questions/37811684/how-to-create-credential-object-needed-by-firebase-web-user-reauthenticatewith)
Read the comments.
By adding just a few lines of code we can save many people a lot of trouble.