### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/auth-next/apple.js
+++ b/auth-next/apple.js
@@ -169,7 +169,7 @@ function appleNonceNode() {
       crypto.randomFillSync(buf);
       nonce = decoder.write(buf);
     }
-    return nonce.substr(0, length);
+    return nonce.slice(0, length);
   };
   
   const unhashedNonce = generateNonce(10);

--- a/auth/apple.js
+++ b/auth/apple.js
@@ -170,7 +170,7 @@ function appleNonceNode() {
       crypto.randomFillSync(buf);
       nonce = decoder.write(buf);
     }
-    return nonce.substr(0, length);
+    return nonce.slice(0, length);
   };
   
   const unhashedNonce = generateNonce(10);

--- a/scripts/separate-snippets.ts
+++ b/scripts/separate-snippets.ts
@@ -77,7 +77,7 @@ function adjustIndentation(lines: string[]) {
     if (isBlank(line)) {
       outputLines.push("");
     } else {
-      outputLines.push(line.substr(minIndent));
+      outputLines.push(line.slice(minIndent));
     }
   }
   return outputLines;

--- a/snippets/auth-next/apple/auth_apple_nonce_node.js
+++ b/snippets/auth-next/apple/auth_apple_nonce_node.js
@@ -17,7 +17,7 @@ const generateNonce = (length) => {
     crypto.randomFillSync(buf);
     nonce = decoder.write(buf);
   }
-  return nonce.substr(0, length);
+  return nonce.slice(0, length);
 };
 
 const unhashedNonce = generateNonce(10);


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.