### PR TITLE
fix error handling on v9 auth snippets

### DIFF
--- a/auth-next/apple.js
+++ b/auth-next/apple.js
@@ -45,7 +45,7 @@ function appleSignInPopup(provider) {
       const errorCode = error.code;
       const errorMessage = error.message;
       // The email of the user's account used.
-      const email = error.email;
+      const email = error.customData.email;
       // The credential that was used.
       const credential = OAuthProvider.credentialFromError(error);
 
@@ -85,7 +85,7 @@ function appleSignInRedirectResult() {
       const errorCode = error.code;
       const errorMessage = error.message;
       // The email of the user's account used.
-      const email = error.email;
+      const email = error.customData.email;
       // The credential that was used.
       const credential = OAuthProvider.credentialFromError(error);
 
@@ -123,7 +123,7 @@ function appleReauthenticatePopup() {
       const errorCode = error.code;
       const errorMessage = error.message;
       // The email of the user's account used.
-      const email = error.email;
+      const email = error.customData.email;
       // The credential that was used.
       const credential = OAuthProvider.credentialFromError(error);
   

--- a/auth-next/facebook.js
+++ b/auth-next/facebook.js
@@ -40,7 +40,7 @@ function facebookSignInPopup(provider) {
       const errorCode = error.code;
       const errorMessage = error.message;
       // The email of the user's account used.
-      const email = error.email;
+      const email = error.customData.email;
       // The AuthCredential type that was used.
       const credential = FacebookAuthProvider.credentialFromError(error);
 
@@ -66,7 +66,7 @@ function facebookSignInRedirectResult() {
       const errorCode = error.code;
       const errorMessage = error.message;
       // The email of the user's account used.
-      const email = error.email;
+      const email = error.customData.email;
       // AuthCredential type that was used.
       const credential = FacebookAuthProvider.credentialFromError(error);
       // ...
@@ -102,7 +102,7 @@ function checkLoginState_wrapper() {
               const errorCode = error.code;
               const errorMessage = error.message;
               // The email of the user's account used.
-              const email = error.email;
+              const email = error.customData.email;
               // The AuthCredential type that was used.
               const credential = FacebookAuthProvider.credentialFromError(error);
               // ...
@@ -156,7 +156,7 @@ function authWithCredential(credential) {
       const errorCode = error.code;
       const errorMessage = error.message;
       // The email of the user's account used.
-      const email = error.email;
+      const email = error.customData.email;
       // The AuthCredential type that was used.
       const credential = FacebookAuthProvider.credentialFromError(error);
       // ...

--- a/auth-next/github.js
+++ b/auth-next/github.js
@@ -46,7 +46,7 @@ function githubSignInPopup(provider) {
       const errorCode = error.code;
       const errorMessage = error.message;
       // The email of the user's account used.
-      const email = error.email;
+      const email = error.customData.email;
       // The AuthCredential type that was used.
       const credential = GithubAuthProvider.credentialFromError(error);
       // ...
@@ -75,7 +75,7 @@ function githubSignInRedirectResult() {
       const errorCode = error.code;
       const errorMessage = error.message;
       // The email of the user's account used.
-      const email = error.email;
+      const email = error.customData.email;
       // The AuthCredential type that was used.
       const credential = GithubAuthProvider.credentialFromError(error);
       // ...

--- a/auth-next/google-signin.js
+++ b/auth-next/google-signin.js
@@ -39,7 +39,7 @@ function googleSignInPopup(provider) {
       const errorCode = error.code;
       const errorMessage = error.message;
       // The email of the user's account used.
-      const email = error.email;
+      const email = error.customData.email;
       // The AuthCredential type that was used.
       const credential = GoogleAuthProvider.credentialFromError(error);
       // ...
@@ -65,7 +65,7 @@ function googleSignInRedirectResult() {
       const errorCode = error.code;
       const errorMessage = error.message;
       // The email of the user's account used.
-      const email = error.email;
+      const email = error.customData.email;
       // The AuthCredential type that was used.
       const credential = GoogleAuthProvider.credentialFromError(error);
       // ...
@@ -87,7 +87,7 @@ function googleBuildAndSignIn(id_token) {
     const errorCode = error.code;
     const errorMessage = error.message;
     // The email of the user's account used.
-    const email = error.email;
+    const email = error.customData.email;
     // The AuthCredential type that was used.
     const credential = GoogleAuthProvider.credentialFromError(error);
     // ...
@@ -123,7 +123,7 @@ function onSignIn_wrapper() {
           const errorCode = error.code;
           const errorMessage = error.message;
           // The email of the user's account used.
-          const email = error.email;
+          const email = error.customData.email;
           // The credential that was used.
           const credential = GoogleAuthProvider.credentialFromError(error);
           // ...

--- a/auth-next/index.js
+++ b/auth-next/index.js
@@ -107,7 +107,7 @@ function authWithCredential(credential) {
       const errorCode = error.code;
       const errorMessage = error.message;
       // The email of the user's account used.
-      const email = error.email;
+      const email = error.customData.email;
       // ...
     });
   // [END auth_signin_credential]

--- a/auth-next/multi-tenancy.js
+++ b/auth-next/multi-tenancy.js
@@ -273,7 +273,7 @@ function accountExistsPopupTenant(auth, samlProvider, googleProvider, goToApp) {
         const pendingCred = error.credential;
         // The credential's tenantId if needed: error.tenantId
         // The provider account's email address.
-        const email = error.email;
+        const email = error.customData.email;
         // Get sign-in methods for this email.
         fetchSignInMethodsForEmail(email, auth)
           .then((methods) => {
@@ -315,7 +315,7 @@ function accountExistsRedirectTenant(auth, samlProvider, googleProvider, goToApp
       // The pending SAML credential.
       pendingCred = error.credential;
       // The provider account's email address.
-      const email = error.email;
+      const email = error.customData.email;
       // Need to set the tenant ID again as the page was reloaded and the
       // previous setting was reset.
       auth.tenantId = tenantId;

--- a/auth-next/oidc.js
+++ b/auth-next/oidc.js
@@ -24,7 +24,7 @@ function oidcSignInPopup(provider) {
       const errorCode = error.code;
       const errorMessage = error.message;
       // The email of the user's account used.
-      const email = error.email;
+      const email = error.customData.email;
       // The AuthCredential type that was used.
       const credential = OAuthProvider.credentialFromError(error);
       // Handle / display error.
@@ -58,7 +58,7 @@ function oidcSignInRedirectResult(provider) {
       const errorCode = error.code;
       const errorMessage = error.message;
       // The email of the user's account used.
-      const email = error.email;
+      const email = error.customData.email;
       // The AuthCredential type that was used.
       const credential = OAuthProvider.credentialFromError(error);
       // Handle / display error.
@@ -86,7 +86,7 @@ function oidcDirectSignIn(provider, oidcIdToken) {
       const errorCode = error.code;
       const errorMessage = error.message;
       // The email of the user's account used.
-      const email = error.email;
+      const email = error.customData.email;
       // The AuthCredential type that was used.
       const credential = OAuthProvider.credentialFromError(error);
       // Handle / display error.

--- a/auth-next/saml.js
+++ b/auth-next/saml.js
@@ -24,7 +24,7 @@ function samlSignInPopup(provider) {
       const errorCode = error.code;
       const errorMessage = error.message;
       // The email of the user's account used.
-      const email = error.email;
+      const email = error.customData.email;
       // The AuthCredential type that was used.
       const credential = SAMLAuthProvider.credentialFromError(error);
       // Handle / display error.
@@ -58,7 +58,7 @@ function samlSignInRedirectResult(provider) {
       const errorCode = error.code;
       const errorMessage = error.message;
       // The email of the user's account used.
-      const email = error.email;
+      const email = error.customData.email;
       // The AuthCredential type that was used.
       const credential = SAMLAuthProvider.credentialFromError(error);
       // Handle / display error.

--- a/auth-next/twitter.js
+++ b/auth-next/twitter.js
@@ -36,7 +36,7 @@ function twitterSignInPopup(provider) {
       const errorCode = error.code;
       const errorMessage = error.message;
       // The email of the user's account used.
-      const email = error.email;
+      const email = error.customData.email;
       // The AuthCredential type that was used.
       const credential = TwitterAuthProvider.credentialFromError(error);
       // ...
@@ -65,7 +65,7 @@ function twitterSignInRedirectResult() {
       const errorCode = error.code;
       const errorMessage = error.message;
       // The email of the user's account used.
-      const email = error.email;
+      const email = error.customData.email;
       // The AuthCredential type that was used.
       const credential = TwitterAuthProvider.credentialFromError(error);
       // ...

--- a/snippets/auth-next/apple/auth_apple_reauthenticate_popup.js
+++ b/snippets/auth-next/apple/auth_apple_reauthenticate_popup.js
@@ -32,7 +32,7 @@ reauthenticateWithPopup(auth.currentUser, provider)
     const errorCode = error.code;
     const errorMessage = error.message;
     // The email of the user's account used.
-    const email = error.email;
+    const email = error.customData.email;
     // The credential that was used.
     const credential = OAuthProvider.credentialFromError(error);
 

--- a/snippets/auth-next/apple/auth_apple_signin_popup.js
+++ b/snippets/auth-next/apple/auth_apple_signin_popup.js
@@ -25,7 +25,7 @@ signInWithPopup(auth, provider)
     const errorCode = error.code;
     const errorMessage = error.message;
     // The email of the user's account used.
-    const email = error.email;
+    const email = error.customData.email;
     // The credential that was used.
     const credential = OAuthProvider.credentialFromError(error);
 

--- a/snippets/auth-next/apple/auth_apple_signin_redirect_result.js
+++ b/snippets/auth-next/apple/auth_apple_signin_redirect_result.js
@@ -25,7 +25,7 @@ getRedirectResult(auth)
     const errorCode = error.code;
     const errorMessage = error.message;
     // The email of the user's account used.
-    const email = error.email;
+    const email = error.customData.email;
     // The credential that was used.
     const credential = OAuthProvider.credentialFromError(error);
 

--- a/snippets/auth-next/facebook/auth_facebook_callback.js
+++ b/snippets/auth-next/facebook/auth_facebook_callback.js
@@ -26,7 +26,7 @@ function checkLoginState(response) {
             const errorCode = error.code;
             const errorMessage = error.message;
             // The email of the user's account used.
-            const email = error.email;
+            const email = error.customData.email;
             // The AuthCredential type that was used.
             const credential = FacebookAuthProvider.credentialFromError(error);
             // ...

--- a/snippets/auth-next/facebook/auth_facebook_signin_credential.js
+++ b/snippets/auth-next/facebook/auth_facebook_signin_credential.js
@@ -19,7 +19,7 @@ signInWithCredential(auth, credential)
     const errorCode = error.code;
     const errorMessage = error.message;
     // The email of the user's account used.
-    const email = error.email;
+    const email = error.customData.email;
     // The AuthCredential type that was used.
     const credential = FacebookAuthProvider.credentialFromError(error);
     // ...

--- a/snippets/auth-next/facebook/auth_facebook_signin_popup.js
+++ b/snippets/auth-next/facebook/auth_facebook_signin_popup.js
@@ -24,7 +24,7 @@ signInWithPopup(auth, provider)
     const errorCode = error.code;
     const errorMessage = error.message;
     // The email of the user's account used.
-    const email = error.email;
+    const email = error.customData.email;
     // The AuthCredential type that was used.
     const credential = FacebookAuthProvider.credentialFromError(error);
 

--- a/snippets/auth-next/facebook/auth_facebook_signin_redirect_result.js
+++ b/snippets/auth-next/facebook/auth_facebook_signin_redirect_result.js
@@ -20,7 +20,7 @@ getRedirectResult(auth)
     const errorCode = error.code;
     const errorMessage = error.message;
     // The email of the user's account used.
-    const email = error.email;
+    const email = error.customData.email;
     // AuthCredential type that was used.
     const credential = FacebookAuthProvider.credentialFromError(error);
     // ...

--- a/snippets/auth-next/github/auth_github_signin_popup.js
+++ b/snippets/auth-next/github/auth_github_signin_popup.js
@@ -22,7 +22,7 @@ signInWithPopup(auth, provider)
     const errorCode = error.code;
     const errorMessage = error.message;
     // The email of the user's account used.
-    const email = error.email;
+    const email = error.customData.email;
     // The AuthCredential type that was used.
     const credential = GithubAuthProvider.credentialFromError(error);
     // ...

--- a/snippets/auth-next/github/auth_github_signin_redirect_result.js
+++ b/snippets/auth-next/github/auth_github_signin_redirect_result.js
@@ -24,7 +24,7 @@ getRedirectResult(auth)
     const errorCode = error.code;
     const errorMessage = error.message;
     // The email of the user's account used.
-    const email = error.email;
+    const email = error.customData.email;
     // The AuthCredential type that was used.
     const credential = GithubAuthProvider.credentialFromError(error);
     // ...

--- a/snippets/auth-next/google-signin/auth_google_build_signin.js
+++ b/snippets/auth-next/google-signin/auth_google_build_signin.js
@@ -17,7 +17,7 @@ signInWithCredential(auth, credential).catch((error) => {
   const errorCode = error.code;
   const errorMessage = error.message;
   // The email of the user's account used.
-  const email = error.email;
+  const email = error.customData.email;
   // The AuthCredential type that was used.
   const credential = GoogleAuthProvider.credentialFromError(error);
   // ...

--- a/snippets/auth-next/google-signin/auth_google_callback.js
+++ b/snippets/auth-next/google-signin/auth_google_callback.js
@@ -25,7 +25,7 @@ function onSignIn(googleUser) {
         const errorCode = error.code;
         const errorMessage = error.message;
         // The email of the user's account used.
-        const email = error.email;
+        const email = error.customData.email;
         // The credential that was used.
         const credential = GoogleAuthProvider.credentialFromError(error);
         // ...

--- a/snippets/auth-next/google-signin/auth_google_signin_credential.js
+++ b/snippets/auth-next/google-signin/auth_google_signin_credential.js
@@ -10,7 +10,7 @@ signInWithCredential(auth, credential).catch((error) => {
   const errorCode = error.code;
   const errorMessage = error.message;
   // The email of the user's account used.
-  const email = error.email;
+  const email = error.customData.email;
   // The credential that was used.
   const credential = GoogleAuthProvider.credentialFromError(error);
   // ...

--- a/snippets/auth-next/google-signin/auth_google_signin_popup.js
+++ b/snippets/auth-next/google-signin/auth_google_signin_popup.js
@@ -21,7 +21,7 @@ signInWithPopup(auth, provider)
     const errorCode = error.code;
     const errorMessage = error.message;
     // The email of the user's account used.
-    const email = error.email;
+    const email = error.customData.email;
     // The AuthCredential type that was used.
     const credential = GoogleAuthProvider.credentialFromError(error);
     // ...

--- a/snippets/auth-next/google-signin/auth_google_signin_redirect_result.js
+++ b/snippets/auth-next/google-signin/auth_google_signin_redirect_result.js
@@ -21,7 +21,7 @@ getRedirectResult(auth)
     const errorCode = error.code;
     const errorMessage = error.message;
     // The email of the user's account used.
-    const email = error.email;
+    const email = error.customData.email;
     // The AuthCredential type that was used.
     const credential = GoogleAuthProvider.credentialFromError(error);
     // ...

--- a/snippets/auth-next/index/auth_signin_credential.js
+++ b/snippets/auth-next/index/auth_signin_credential.js
@@ -19,7 +19,7 @@ signInWithCredential(auth, credential)
     const errorCode = error.code;
     const errorMessage = error.message;
     // The email of the user's account used.
-    const email = error.email;
+    const email = error.customData.email;
     // ...
   });
 // [END auth_signin_credential_modular]

--- a/snippets/auth-next/multi-tenancy/multitenant_account_exists_popup.js
+++ b/snippets/auth-next/multi-tenancy/multitenant_account_exists_popup.js
@@ -19,7 +19,7 @@ signInWithPopup(auth, samlProvider)
       const pendingCred = error.credential;
       // The credential's tenantId if needed: error.tenantId
       // The provider account's email address.
-      const email = error.email;
+      const email = error.customData.email;
       // Get sign-in methods for this email.
       fetchSignInMethodsForEmail(email, auth)
         .then((methods) => {

--- a/snippets/auth-next/multi-tenancy/multitenant_account_exists_redirect.js
+++ b/snippets/auth-next/multi-tenancy/multitenant_account_exists_redirect.js
@@ -20,7 +20,7 @@ getRedirectResult(auth).catch((error) => {
     // The pending SAML credential.
     pendingCred = error.credential;
     // The provider account's email address.
-    const email = error.email;
+    const email = error.customData.email;
     // Need to set the tenant ID again as the page was reloaded and the
     // previous setting was reset.
     auth.tenantId = tenantId;

--- a/snippets/auth-next/oidc/auth_oidc_direct_sign_in.js
+++ b/snippets/auth-next/oidc/auth_oidc_direct_sign_in.js
@@ -22,7 +22,7 @@ signInWithCredential(auth, credential)
     const errorCode = error.code;
     const errorMessage = error.message;
     // The email of the user's account used.
-    const email = error.email;
+    const email = error.customData.email;
     // The AuthCredential type that was used.
     const credential = OAuthProvider.credentialFromError(error);
     // Handle / display error.

--- a/snippets/auth-next/oidc/auth_oidc_signin_popup.js
+++ b/snippets/auth-next/oidc/auth_oidc_signin_popup.js
@@ -18,7 +18,7 @@ signInWithPopup(auth, provider)
     const errorCode = error.code;
     const errorMessage = error.message;
     // The email of the user's account used.
-    const email = error.email;
+    const email = error.customData.email;
     // The AuthCredential type that was used.
     const credential = OAuthProvider.credentialFromError(error);
     // Handle / display error.

--- a/snippets/auth-next/oidc/auth_oidc_signin_redirect_result.js
+++ b/snippets/auth-next/oidc/auth_oidc_signin_redirect_result.js
@@ -19,7 +19,7 @@ getRedirectResult(auth)
     const errorCode = error.code;
     const errorMessage = error.message;
     // The email of the user's account used.
-    const email = error.email;
+    const email = error.customData.email;
     // The AuthCredential type that was used.
     const credential = OAuthProvider.credentialFromError(error);
     // Handle / display error.

--- a/snippets/auth-next/saml/auth_saml_signin_popup.js
+++ b/snippets/auth-next/saml/auth_saml_signin_popup.js
@@ -18,7 +18,7 @@ signInWithPopup(auth, provider)
     const errorCode = error.code;
     const errorMessage = error.message;
     // The email of the user's account used.
-    const email = error.email;
+    const email = error.customData.email;
     // The AuthCredential type that was used.
     const credential = SAMLAuthProvider.credentialFromError(error);
     // Handle / display error.

--- a/snippets/auth-next/saml/auth_saml_signin_redirect_result.js
+++ b/snippets/auth-next/saml/auth_saml_signin_redirect_result.js
@@ -19,7 +19,7 @@ getRedirectResult(auth)
     const errorCode = error.code;
     const errorMessage = error.message;
     // The email of the user's account used.
-    const email = error.email;
+    const email = error.customData.email;
     // The AuthCredential type that was used.
     const credential = SAMLAuthProvider.credentialFromError(error);
     // Handle / display error.

--- a/snippets/auth-next/twitter/auth_twitter_signin_popup.js
+++ b/snippets/auth-next/twitter/auth_twitter_signin_popup.js
@@ -24,7 +24,7 @@ signInWithPopup(auth, provider)
     const errorCode = error.code;
     const errorMessage = error.message;
     // The email of the user's account used.
-    const email = error.email;
+    const email = error.customData.email;
     // The AuthCredential type that was used.
     const credential = TwitterAuthProvider.credentialFromError(error);
     // ...

--- a/snippets/auth-next/twitter/auth_twitter_signin_redirect_result.js
+++ b/snippets/auth-next/twitter/auth_twitter_signin_redirect_result.js
@@ -24,7 +24,7 @@ getRedirectResult(auth)
     const errorCode = error.code;
     const errorMessage = error.message;
     // The email of the user's account used.
-    const email = error.email;
+    const email = error.customData.email;
     // The AuthCredential type that was used.
     const credential = TwitterAuthProvider.credentialFromError(error);
     // ...

--- a/snippets/database-next/read-and-write/rtdb_social_write_fan_out.js
+++ b/snippets/database-next/read-and-write/rtdb_social_write_fan_out.js
@@ -5,7 +5,7 @@
 // 'npm run snippets'.
 
 // [START rtdb_social_write_fan_out_modular]
-import { getDatabase, ref, child, push, update } from "firebase/database";
+import { getDatabase, ref, update, push, child } from "firebase/database";
 
 function writeNewPost(uid, username, picture, title, body) {
   const db = getDatabase();

--- a/snippets/database-next/read-and-write/rtdb_social_write_fan_out.js
+++ b/snippets/database-next/read-and-write/rtdb_social_write_fan_out.js
@@ -5,8 +5,6 @@
 // 'npm run snippets'.
 
 // [START rtdb_social_write_fan_out_modular]
-import { getDatabase, ref, child, push, update } from "firebase/database";
-
 function writeNewPost(uid, username, picture, title, body) {
   const db = getDatabase();
 

--- a/snippets/database-next/read-and-write/rtdb_social_write_fan_out.js
+++ b/snippets/database-next/read-and-write/rtdb_social_write_fan_out.js
@@ -5,7 +5,7 @@
 // 'npm run snippets'.
 
 // [START rtdb_social_write_fan_out_modular]
-import { getDatabase, ref, update, push, child } from "firebase/database";
+import { getDatabase, ref, child, push, update } from "firebase/database";
 
 function writeNewPost(uid, username, picture, title, body) {
   const db = getDatabase();

--- a/snippets/database-next/read-and-write/rtdb_social_write_fan_out.js
+++ b/snippets/database-next/read-and-write/rtdb_social_write_fan_out.js
@@ -5,6 +5,8 @@
 // 'npm run snippets'.
 
 // [START rtdb_social_write_fan_out_modular]
+import { getDatabase, ref, child, push, update } from "firebase/database";
+
 function writeNewPost(uid, username, picture, title, body) {
   const db = getDatabase();
 


### PR DESCRIPTION
Starting in v9, the user email tied to an error should be accessed from the `customData` nested object.

Fixes #286 