### PR TITLE
analytics select_content should not have items

### DIFF
--- a/analytics-next/index.js
+++ b/analytics-next/index.js
@@ -27,8 +27,7 @@ function logEventParams() {
   const analytics = getAnalytics();
   logEvent(analytics, 'select_content', {
     content_type: 'image',
-    content_id: 'P12453',
-    items: [{ name: 'Kittens' }]
+    content_id: 'P12453'
   });
   // [END analytics_log_event_params]
 }

--- a/snippets/analytics-next/index/analytics_log_event_params.js
+++ b/snippets/analytics-next/index/analytics_log_event_params.js
@@ -10,6 +10,7 @@ import { getAnalytics, logEvent } from "firebase/analytics";
 const analytics = getAnalytics();
 logEvent(analytics, 'select_content', {
   content_type: 'image',
-  content_id: 'P12453'
+  content_id: 'P12453',
+  items: [{ name: 'Kittens' }]
 });
 // [END analytics_log_event_params_modular]

--- a/snippets/analytics-next/index/analytics_log_event_params.js
+++ b/snippets/analytics-next/index/analytics_log_event_params.js
@@ -10,7 +10,6 @@ import { getAnalytics, logEvent } from "firebase/analytics";
 const analytics = getAnalytics();
 logEvent(analytics, 'select_content', {
   content_type: 'image',
-  content_id: 'P12453',
-  items: [{ name: 'Kittens' }]
+  content_id: 'P12453'
 });
 // [END analytics_log_event_params_modular]


### PR DESCRIPTION
There's an error in the Analytics docs [here](https://firebase.google.com/docs/analytics/events?platform=web#log_events_5). The code snippet is for the `select_content` event, but in the Events [documentation](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#select_content), `select_content` doesn't have `items`. This PR removes `items`.