### PR TITLE
(doc): fix an incorrect snippet

### DIFF
--- a/snippets/auth-next/index/auth_set_language_code.js
+++ b/snippets/auth-next/index/auth_set_language_code.js
@@ -10,5 +10,5 @@ import { getAuth } from "firebase/auth";
 const auth = getAuth();
 auth.languageCode = 'it';
 // To apply the default browser preference instead of explicitly setting it.
-// firebase.auth().useDeviceLanguage();
+// auth.useDeviceLanguage();
 // [END auth_set_language_code_modular]


### PR DESCRIPTION
For `auth_set_language_code.js`, the snippet for version 9 is incorrect. Presumably, it took the version 8's and hasn't been updated to correctly reflect version 9.

To use the device's language, `useDeviceLanguage()` has to be called directly from `auth` not `firebase.auth()` like version 8.

```diff
import { getAuth } from "firebase/auth";

const auth = getAuth();
auth.languageCode = 'it';
// To apply the default browser preference instead of explicitly setting it.
- // firebase.auth().useDeviceLanguage();
+ // auth.useDeviceLanguage();
```