### PR TITLE
fix broken ref docs urls

### DIFF
--- a/auth-next/index.js
+++ b/auth-next/index.js
@@ -52,7 +52,7 @@ function authStateListener() {
   onAuthStateChanged(auth, (user) => {
     if (user) {
       // User is signed in, see docs for a list of available properties
-      // https://firebase.google.com/docs/reference/js/firebase.User
+      // https://firebase.google.com/docs/reference/js/v8/firebase.User
       const uid = user.uid;
       // ...
     } else {
@@ -72,7 +72,7 @@ function currentUser() {
 
   if (user) {
     // User is signed in, see docs for a list of available properties
-    // https://firebase.google.com/docs/reference/js/firebase.User
+    // https://firebase.google.com/docs/reference/js/v8/firebase.User
     // ...
   } else {
     // No user is signed in.

--- a/auth/index.js
+++ b/auth/index.js
@@ -43,7 +43,7 @@ function authStateListener() {
   firebase.auth().onAuthStateChanged((user) => {
     if (user) {
       // User is signed in, see docs for a list of available properties
-      // https://firebase.google.com/docs/reference/js/firebase.User
+      // https://firebase.google.com/docs/reference/js/v8/firebase.User
       var uid = user.uid;
       // ...
     } else {
@@ -60,7 +60,7 @@ function currentUser() {
 
   if (user) {
     // User is signed in, see docs for a list of available properties
-    // https://firebase.google.com/docs/reference/js/firebase.User
+    // https://firebase.google.com/docs/reference/js/v8/firebase.User
     // ...
   } else {
     // No user is signed in.

--- a/firestore/test.firestore.js
+++ b/firestore/test.firestore.js
@@ -600,7 +600,7 @@ describe("firestore", () => {
             var docRef = db.collection("cities").doc("SF");
 
             // Valid options for source are 'server', 'cache', or
-            // 'default'. See https://firebase.google.com/docs/reference/js/firebase.firestore.GetOptions
+            // 'default'. See https://firebase.google.com/docs/reference/js/v8/firebase.firestore.GetOptions
             // for more information.
             var getOptions = {
                 source: 'cache'

--- a/scripts/separate-snippets.ts
+++ b/scripts/separate-snippets.ts
@@ -47,10 +47,7 @@ function replaceRefDocsUrls(lines: string[]) {
   for (const line of lines) {
     if (line.match(RE_REF_DOCS)) {
       outputLines.push(line.replace(RE_REF_DOCS, (match: string, p1?: string) => {
-        if (p1) {
-          return `https://firebase.google.com/docs/reference/js/${REF_DOCS_MAPPINGS[p1]}`;
-        }
-        return match;
+        return p1 ? `https://firebase.google.com/docs/reference/js/${REF_DOCS_MAPPINGS[p1]}` : match;
       }));
     } else {
       outputLines.push(line);

--- a/scripts/separate-snippets.ts
+++ b/scripts/separate-snippets.ts
@@ -18,6 +18,15 @@ const RE_END_SNIPPET = /\[END\s+([A-Za-z_]+)\s*\]/;
 // TODO: Handle multiline imports?
 const RE_REQUIRE = /const {(.+?)} = require\((.+?)\)/;
 
+// Regex for ref docs URLs
+// eg. "https://firebase.google.com/docs/reference/js/v8/firebase.User"
+const RE_REF_DOCS = /https:\/\/firebase\.google\.com\/docs\/reference\/js\/(.*)/;
+
+// Maps v8 ref docs URLs to their v9 counterpart
+const REF_DOCS_MAPPINGS: { [key: string]: string } = {
+  "v8/firebase.User" : "auth.user"
+};
+
 type SnippetsConfig = {
   enabled: boolean;
   suffix: string;
@@ -28,6 +37,26 @@ const DEFAULT_SUFFIX = "_modular";
 
 function isBlank(line: string) {
   return line.trim().length === 0;
+}
+
+/**
+ * Replace all v8 ref doc urls with their v9 counterpart.
+ */
+function replaceRefDocsUrls(lines: string[]) {
+  const outputLines = [];
+  for (const line of lines) {
+    if (line.match(RE_REF_DOCS)) {
+      outputLines.push(line.replace(RE_REF_DOCS, (match: string, p1?: string) => {
+        if (p1) {
+          return `https://firebase.google.com/docs/reference/js/${REF_DOCS_MAPPINGS[p1]}`;
+        }
+        return match;
+      }));
+    } else {
+      outputLines.push(line);
+    }
+  }
+  return outputLines;
 }
 
 /**
@@ -119,6 +148,7 @@ function processSnippet(
   outputLines = addSuffixToSnippetNames(outputLines, snippetSuffix);
   outputLines = adjustIndentation(outputLines);
   outputLines = removeFirstLineAfterComments(outputLines);
+  outputLines = replaceRefDocsUrls(outputLines);
 
   // Add a preamble to every snippet
   const preambleLines = [

--- a/snippets/auth-next/index/auth_current_user.js
+++ b/snippets/auth-next/index/auth_current_user.js
@@ -12,7 +12,7 @@ const user = auth.currentUser;
 
 if (user) {
   // User is signed in, see docs for a list of available properties
-  // https://firebase.google.com/docs/reference/js/firebase.User
+  // https://firebase.google.com/docs/reference/js/v8/firebase.User
   // ...
 } else {
   // No user is signed in.

--- a/snippets/auth-next/index/auth_current_user.js
+++ b/snippets/auth-next/index/auth_current_user.js
@@ -12,7 +12,7 @@ const user = auth.currentUser;
 
 if (user) {
   // User is signed in, see docs for a list of available properties
-  // https://firebase.google.com/docs/reference/js/v8/firebase.User
+  // https://firebase.google.com/docs/reference/js/auth.user
   // ...
 } else {
   // No user is signed in.

--- a/snippets/auth-next/index/auth_state_listener.js
+++ b/snippets/auth-next/index/auth_state_listener.js
@@ -11,7 +11,7 @@ const auth = getAuth();
 onAuthStateChanged(auth, (user) => {
   if (user) {
     // User is signed in, see docs for a list of available properties
-    // https://firebase.google.com/docs/reference/js/firebase.User
+    // https://firebase.google.com/docs/reference/js/v8/firebase.User
     const uid = user.uid;
     // ...
   } else {

--- a/snippets/auth-next/index/auth_state_listener.js
+++ b/snippets/auth-next/index/auth_state_listener.js
@@ -11,7 +11,7 @@ const auth = getAuth();
 onAuthStateChanged(auth, (user) => {
   if (user) {
     // User is signed in, see docs for a list of available properties
-    // https://firebase.google.com/docs/reference/js/v8/firebase.User
+    // https://firebase.google.com/docs/reference/js/auth.user
     const uid = user.uid;
     // ...
   } else {


### PR DESCRIPTION
Closes #341 

This PR should:
- Fix broken v8 ref doc urls:
    - `js/firebase.User` --> `js/v8/firebase.User`
    - `js/firebase.firestore.GetOptions` --> `js/v8/firebase.firestore.GetOptions`
- Update the separate-snippets.ts script to properly map v8 urls to v9 when generating the modular snippets.