### PR TITLE
missing keyword await fixed issue #330

### DIFF
--- a/snippets/firestore-next/test-firestore/set_with_merge.js
+++ b/snippets/firestore-next/test-firestore/set_with_merge.js
@@ -7,6 +7,6 @@
 // [START set_with_merge_modular]
 import { doc, setDoc } from "firebase/firestore"; 
 
-const cityRef = await doc(db, 'cities', 'BJ');
-setDoc(cityRef, { capital: true }, { merge: true });
+const cityRef = doc(db, 'cities', 'BJ');
+await setDoc(cityRef, { capital: true }, { merge: true });
 // [END set_with_merge_modular]

--- a/snippets/firestore-next/test-firestore/set_with_merge.js
+++ b/snippets/firestore-next/test-firestore/set_with_merge.js
@@ -7,6 +7,6 @@
 // [START set_with_merge_modular]
 import { doc, setDoc } from "firebase/firestore"; 
 
-const cityRef = doc(db, 'cities', 'BJ');
+const cityRef = await doc(db, 'cities', 'BJ');
 setDoc(cityRef, { capital: true }, { merge: true });
 // [END set_with_merge_modular]


### PR DESCRIPTION
fixed issue #330 
The docs related to Set a document [see here](https://firebase.google.com/docs/firestore/manage-data/add-data?hl=en&authuser=0#add_a_document:~:text=If%20the%20document%20does%20not%20exist%2C%20it%20will%20be%20created.%20If%20the%20document%20does%20exist%2C%20its%20contents%20will%20be%20overwritten%20with%20the%20newly%20provided%20data%2C%20unless%20you%20specify%20that%20the%20data%20should%20be%20merged%20into%20the%20existing%20document%2C%20as%20follows%3A) are missing the keyword await before setDoc() function.
For the code example where the { merge: true} is used.