### PR TITLE
Implement missing multipart/form-data handling in auth-next's service-worker-sessions.

### DIFF
--- a/auth-next/service-worker-sessions.js
+++ b/auth-next/service-worker-sessions.js
@@ -75,6 +75,10 @@ function svcIntercept() {
             .then((json) => {
               return JSON.stringify(json);
             });
+        } else if (
+          req.headers.get('Content-Type').indexOf('multipart/form-data') !== -1
+        ) {
+          return req.clone().arrayBuffer();
         } else {
           return req.text();
         }


### PR DESCRIPTION
## What steps will reproduce the problem:

1. Start the service worker session in the auth-next snippet.
2. Attempt to upload a file using a form with enctype="multipart/form-data".
3. Observe that the session does not handle the multipart/form-data POST request correctly.

## What is the expected result?

The service worker session should correctly handle multipart/form-data encoded forms, parsing the file input and passing it along to the server without issues.

## What happens instead of that?

The service worker cannot process the multipart/form-data content type and returns buffer information in the body as text data.

The file upload succeeds, but the file is corrupted due to this.