### PR TITLE
fixed missing await keyword

### DIFF
--- a/snippets/firestore-next/test-firestore/set_with_merge.js
+++ b/snippets/firestore-next/test-firestore/set_with_merge.js
@@ -8,5 +8,5 @@
 import { doc, setDoc } from "firebase/firestore"; 
 
 const cityRef = doc(db, 'cities', 'BJ');
-setDoc(cityRef, { capital: true }, { merge: true });
+await setDoc(cityRef, { capital: true }, { merge: true });
 // [END set_with_merge_modular]


### PR DESCRIPTION
I have added the `await` keyword that was missing before the `setDoc()` function.