### PR TITLE
Upgrade versions in FCM service worker

### DIFF
--- a/messaging/service-worker.js
+++ b/messaging/service-worker.js
@@ -10,8 +10,8 @@ function initInSw() {
   // Give the service worker access to Firebase Messaging.
   // Note that you can only use Firebase Messaging here. Other Firebase libraries
   // are not available in the service worker.
-  importScripts('https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js');
-  importScripts('https://www.gstatic.com/firebasejs/8.10.1/firebase-messaging.js');
+  importScripts('https://www.gstatic.com/firebasejs/10.13.2/firebase-app-compat.js');
+  importScripts('https://www.gstatic.com/firebasejs/10.13.2/firebase-messaging-compat.js');
 
   // Initialize the Firebase app in the service worker by passing in
   // your app's Firebase config object.

--- a/messaging/service-worker.js
+++ b/messaging/service-worker.js
@@ -10,6 +10,7 @@ function initInSw() {
   // Give the service worker access to Firebase Messaging.
   // Note that you can only use Firebase Messaging here. Other Firebase libraries
   // are not available in the service worker.
+  // Replace 10.13.2 with latest version of the Firebase JS SDK.
   importScripts('https://www.gstatic.com/firebasejs/10.13.2/firebase-app-compat.js');
   importScripts('https://www.gstatic.com/firebasejs/10.13.2/firebase-messaging-compat.js');
 


### PR DESCRIPTION
We haven't updated the version since v9+ uses ESM syntax which isn't supported in service workers. We should update this version, but instead point to the compat packages since those use the namespaced API.