### PR TITLE
Update incorrect mention of "upload" in a download example.

### DIFF
--- a/storage/download-files.js
+++ b/storage/download-files.js
@@ -66,7 +66,7 @@ function downloadFullExample() {
         // User doesn't have permission to access the object
         break;
       case 'storage/canceled':
-        // User canceled the upload
+        // User canceled the download
         break;
 
       // ...


### PR DESCRIPTION
In code that provides an example of how to download a file, there is an incorrect mention of uploading.