### PR TITLE
RC doc update to provide default prod value for minimumFetchIntervalMillis

### DIFF
--- a/remoteconfig-next/index.js
+++ b/remoteconfig-next/index.js
@@ -14,6 +14,7 @@ function getInstance() {
 function setMinimumFetchTime() {
   const remoteConfig = getInstance();
   // [START rc_set_minimum_fetch_time]
+  // The default and recommended production fetch interval for Remote Config is 12 hours
   remoteConfig.settings.minimumFetchIntervalMillis = 3600000;
   // [END rc_set_minimum_fetch_time]
 }

--- a/snippets/remoteconfig-next/index/rc_set_minimum_fetch_time.js
+++ b/snippets/remoteconfig-next/index/rc_set_minimum_fetch_time.js
@@ -5,5 +5,6 @@
 // 'npm run snippets'.
 
 // [START rc_set_minimum_fetch_time_modular]
+// The default and recommended production fetch interval for Remote Config is 12 hours.
 remoteConfig.settings.minimumFetchIntervalMillis = 3600000;
 // [END rc_set_minimum_fetch_time_modular]

--- a/snippets/remoteconfig-next/index/rc_set_minimum_fetch_time.js
+++ b/snippets/remoteconfig-next/index/rc_set_minimum_fetch_time.js
@@ -5,6 +5,5 @@
 // 'npm run snippets'.
 
 // [START rc_set_minimum_fetch_time_modular]
-// The default and recommended production fetch interval for Remote Config is 12 hours.
 remoteConfig.settings.minimumFetchIntervalMillis = 3600000;
 // [END rc_set_minimum_fetch_time_modular]

--- a/snippets/remoteconfig-next/index/rc_set_minimum_fetch_time.js
+++ b/snippets/remoteconfig-next/index/rc_set_minimum_fetch_time.js
@@ -5,6 +5,6 @@
 // 'npm run snippets'.
 
 // [START rc_set_minimum_fetch_time_modular]
-// The default and recommended production fetch interval for Remote Config is 12 hours.
+// The default and recommended production fetch interval for Remote Config is 12 hours
 remoteConfig.settings.minimumFetchIntervalMillis = 3600000;
 // [END rc_set_minimum_fetch_time_modular]


### PR DESCRIPTION
This PR is to address the bug in documentation mentioned in https://github.com/firebase/firebase-js-sdk/issues/2841. Developers are assuming that the value we provided is the recommended prod min fetch interval and running into throttling issues. 