### PR TITLE
Update email link auth snippet to stop using deprecated `dynamicLinkDomain`

### DIFF
--- a/auth-next/email-link-auth.js
+++ b/auth-next/email-link-auth.js
@@ -19,7 +19,8 @@ function emailLinkActionCodeSettings() {
       installApp: true,
       minimumVersion: '12'
     },
-    dynamicLinkDomain: 'example.page.link'
+    // The domain must be configured in Firebase Hosting and owned by the project.
+    linkDomain: 'example.com'
   };
   // [END auth_email_link_actioncode_settings]
 }

--- a/auth-next/email-link-auth.js
+++ b/auth-next/email-link-auth.js
@@ -20,7 +20,7 @@ function emailLinkActionCodeSettings() {
       minimumVersion: '12'
     },
     // The domain must be configured in Firebase Hosting and owned by the project.
-    linkDomain: 'example.com'
+    linkDomain: 'custom-domain.com'
   };
   // [END auth_email_link_actioncode_settings]
 }

--- a/snippets/auth-next/email-link-auth/auth_email_link_actioncode_settings.js
+++ b/snippets/auth-next/email-link-auth/auth_email_link_actioncode_settings.js
@@ -19,6 +19,7 @@ const actionCodeSettings = {
     installApp: true,
     minimumVersion: '12'
   },
-  dynamicLinkDomain: 'example.page.link'
+  // The domain must be configured in Firebase Hosting and owned by the project.
+  linkDomain: 'example.com'
 };
 // [END auth_email_link_actioncode_settings_modular]

--- a/snippets/auth-next/email-link-auth/auth_email_link_actioncode_settings.js
+++ b/snippets/auth-next/email-link-auth/auth_email_link_actioncode_settings.js
@@ -20,6 +20,6 @@ const actionCodeSettings = {
     minimumVersion: '12'
   },
   // The domain must be configured in Firebase Hosting and owned by the project.
-  linkDomain: 'example.com'
+  linkDomain: 'custom-domain.com'
 };
 // [END auth_email_link_actioncode_settings_modular]


### PR DESCRIPTION
Update email link sign-in snippet to stop using `dynamicLinkDomain` as it's being deprecated.

Snippet used in https://firebase.google.com/docs/auth/web/email-link-auth#send_an_authentication_link_to_the_users_email_address.