### PR TITLE
docs: add missing await to setDoc merge example

### DIFF
--- a/snippets/firestore-next/test-firestore/set_with_merge.js
+++ b/snippets/firestore-next/test-firestore/set_with_merge.js
@@ -8,5 +8,5 @@
 import { doc, setDoc } from "firebase/firestore"; 
 
 const cityRef = doc(db, 'cities', 'BJ');
-setDoc(cityRef, { capital: true }, { merge: true });
+await setDoc(cityRef, { capital: true }, { merge: true });
 // [END set_with_merge_modular]


### PR DESCRIPTION
This PR fixes a documentation inconsistency where the `setDoc()` example
using `{ merge: true }` was missing the `await` keyword.

`setDoc()` is async regardless of the `merge` option, and other examples
on the same page already include `await`.

Fixes #330.